### PR TITLE
Add stream-chain dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "p-limit": "^7.2.0",
     "piscina": "^5.1.3",
     "rbush": "^4.0.1",
+    "stream-chain": "^3.4.0",
     "stream-json": "^1.9.1"
   }
 }


### PR DESCRIPTION
As above.
Otherwise you get the following error when running `scripts/process-data.js`:
```
~\Documents\SubwayBuilder\Subway-Builder-map-patcher λ node .\scripts\process-data.js
node:internal/modules/esm/resolve:845
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'stream-chain' imported from MYPATH\Subway-Builder-map-patcher\scripts\process-data.js
    at packageResolve (node:internal/modules/esm/resolve:845:9)
    at moduleResolve (node:internal/modules/esm/resolve:918:18)
    at defaultResolve (node:internal/modules/esm/resolve:1148:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:390:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:359:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:234:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:87:39)
    at link (node:internal/modules/esm/module_job:86:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```